### PR TITLE
change feels.ink to alternate

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="fresh.css">
 <link rel="stylesheet" href="frozen.css" media="(color)">
 <link rel="canonical" href="https://s9a.github.io">
-<link rel="canonical" href="https://feels.ink">
+<link rel="alternate" href="https://feels.ink">
 
 <body class="hood">
 


### PR DESCRIPTION
change [`[rel]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) for [feels.ink](https://feels.ink) from `canonical` to `alternate` because Lighthouse recommends having exactly one canonical URL and [feels.ink](https://feels.ink) currently redirects to [s9a.github.io](https://s9a.github.io)